### PR TITLE
Render comment field explicitly in submission detail

### DIFF
--- a/apps/comments/tests.py
+++ b/apps/comments/tests.py
@@ -38,3 +38,8 @@ class CommentFormTests(TestCase):
     def test_empty_form(self):
         form = CommentForm(data={'content': ''})
         self.assertFalse(form.is_valid())
+
+    def test_help_text_ascii(self):
+        form = CommentForm()
+        help_text = form.fields['content'].help_text or ''
+        self.assertTrue(help_text.isascii())

--- a/templates/submissions/detail.html
+++ b/templates/submissions/detail.html
@@ -54,8 +54,15 @@
     {% if can_comment %}
       <form method="post">
         {% csrf_token %}
-        {{ comment_form.as_p }}
-        <button type="submit">Add Comment</button>
+        <div class="field">
+          {{ comment_form.content.label_tag }}
+          {{ comment_form.content.help_text }}
+          {{ comment_form.content }}
+          {{ comment_form.content.errors }}
+        </div>
+        <div class="actions">
+          <button type="submit">Add Comment</button>
+        </div>
       </form>
     {% else %}
       {% if user.is_authenticated %}


### PR DESCRIPTION
## Summary
- replace implicit comment form with explicit field markup and action wrapper
- assert comment field help text is ASCII

## Testing
- `uv run python manage.py check`
- `uv run python manage.py makemigrations --check --dry-run`
- `uv run python manage.py test -v 2`

------
https://chatgpt.com/codex/tasks/task_e_68c1d9017f808324b838bcd4f04ad61c