### PR TITLE
Rename stack tags to generic tags

### DIFF
--- a/apps/core/utils.py
+++ b/apps/core/utils.py
@@ -5,14 +5,14 @@ from django.core.cache import cache
 
 def get_tag_items():
     """Return ordered tag names, tag items and slug-to-name mapping."""
-    cache_key = 'tags:v1'
+    cache_key = 'tags:v2'
     cached = cache.get(cache_key)
     if cached:
         return cached
 
     names = []
-    for s in Submission.objects.filter(status='published').prefetch_related('stack_tags'):
-        names.extend([t for t in s.stack_tags.names() if t])
+    for s in Submission.objects.filter(status='published').prefetch_related('tags'):
+        names.extend([t for t in s.tags.names() if t])
     seen = set()
     names = [t for t in names if not (t in seen or seen.add(t))]
     tag_items = []

--- a/apps/core/views.py
+++ b/apps/core/views.py
@@ -37,7 +37,7 @@ class TagView(TemplateView):
 
         qs = Submission.objects.filter(status='published').order_by('-created_at')
         if active_name:
-            qs = qs.filter(stack_tags__name__in=[active_name])
+            qs = qs.filter(tags__name__in=[active_name])
 
         from django.core.paginator import Paginator
         paginator = Paginator(qs, 20)

--- a/apps/submissions/fixtures/internetguzeldir_submission.json
+++ b/apps/submissions/fixtures/internetguzeldir_submission.json
@@ -20,7 +20,7 @@
         "https://internetguzeldir.com/arsiv",
         "https://internetguzeldir.com/rss.xml"
       ],
-      "stack_tags": [],
+      "tags": [],
       "status": "published",
       "created_at": "2024-09-01T09:00:00Z",
       "updated_at": "2024-09-01T09:00:00Z"

--- a/apps/submissions/forms.py
+++ b/apps/submissions/forms.py
@@ -32,12 +32,17 @@ class SubmissionForm(forms.ModelForm):
         help_text='One URL per line. Add relevant links (demo, landing page, repo).',
         widget=forms.Textarea(attrs={'rows': 2})
     )
+    tags = TagField(
+        label='Tags (Optional)',
+        required=False,
+        help_text='Comma-separated tags for this submission.',
+    )
 
     class Meta:
         model = Submission
         fields = [
             'project_name', 'tagline', 'is_anonymous', 'birth_year', 'lifespan',
-            'description', 'idea', 'tech', 'wins', 'failure', 'lessons',
+            'description', 'idea', 'tech', 'tags', 'wins', 'failure', 'lessons',
         ]
         labels = {
             'tagline': 'Tagline',
@@ -122,6 +127,10 @@ class SubmissionForm(forms.ModelForm):
 
     def clean_lessons(self):
         return strip_h1_h2(self.cleaned_data.get('lessons', ''))
+
+    def clean_tags(self):
+        tags = self.cleaned_data.get('tags') or []
+        return [t.strip() for t in tags if t.strip()]
 
     def clean(self):
         cleaned = super().clean()

--- a/apps/submissions/management/commands/seed_submissions.py
+++ b/apps/submissions/management/commands/seed_submissions.py
@@ -89,7 +89,7 @@ class Command(BaseCommand):
             # tags
             tags = list({random.choice(["python", "django", "react", "redis", "celery", "postgres", "docker", "aws"]) for _ in range(random.randint(1, 4))})
             if tags:
-                s.stack_tags.add(*tags)
+                s.tags.add(*tags)
             created += 1
 
         self.stdout.write(self.style.SUCCESS(f"Created {created} submissions (user @{user.username})."))

--- a/apps/submissions/migrations/0019_rename_stack_tags_to_tags.py
+++ b/apps/submissions/migrations/0019_rename_stack_tags_to_tags.py
@@ -1,0 +1,15 @@
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("submissions", "0018_add_description"),
+    ]
+
+    operations = [
+        migrations.RenameField(
+            model_name="submission",
+            old_name="stack_tags",
+            new_name="tags",
+        ),
+    ]

--- a/apps/submissions/models.py
+++ b/apps/submissions/models.py
@@ -56,7 +56,7 @@ class Submission(models.Model):
     wins = models.TextField(blank=True, default="")
 
     links_json = models.JSONField(default=list, blank=True)
-    stack_tags = TaggableManager(blank=True)
+    tags = TaggableManager(blank=True)
     # timeline_text removed for MVP
     # revenue_text removed for MVP
     # spend_text removed for MVP

--- a/apps/submissions/tests/test_forms.py
+++ b/apps/submissions/tests/test_forms.py
@@ -43,3 +43,9 @@ class SubmissionFormTests(TestCase):
             "http://example.com",
             "https://foo.com",
         ])
+
+    def test_tags_parsed(self):
+        data = self._valid_data(tags="python, django, ")
+        form = SubmissionForm(data)
+        self.assertTrue(form.is_valid())
+        self.assertCountEqual(form.cleaned_data["tags"], ["python", "django"])

--- a/apps/submissions/tests/test_views.py
+++ b/apps/submissions/tests/test_views.py
@@ -1,0 +1,60 @@
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[3]))
+
+from datetime import date
+from django.test import TestCase
+from django.urls import reverse
+from django.contrib.auth import get_user_model
+
+from apps.submissions.models import Submission
+
+
+class SubmitViewTests(TestCase):
+    def setUp(self):
+        self.user = get_user_model().objects.create_user(
+            username="u1", password="pw"
+        )
+        self.client.force_login(self.user)
+
+    def _post_data(self, **overrides):
+        data = {
+            "project_name": "Test Project",
+            "tagline": "Short one line",
+            "birth_year": date.today().year,
+            "idea": "idea",
+            "tech": "tech",
+            "failure": "fail",
+            "lessons": "lessons",
+            "tags": "python, django",
+        }
+        data.update(overrides)
+        return data
+
+    def test_create_submission_saves_tags(self):
+        resp = self.client.post(reverse("submit"), self._post_data())
+        self.assertEqual(resp.status_code, 302)
+        sub = Submission.objects.get(project_name="Test Project")
+        self.assertCountEqual(sub.tags.names(), ["python", "django"])
+
+    def test_edit_submission_updates_tags(self):
+        sub = Submission.objects.create(
+            user=self.user,
+            project_name="Test Project",
+            tagline="Short one line",
+            birth_year=date.today().year,
+            idea="idea",
+            tech="tech",
+            failure="fail",
+            lessons="lessons",
+        )
+        sub.tags.add("python")
+        url = reverse("submit_edit", args=[sub.slug])
+        resp = self.client.post(
+            url, self._post_data(tags="go, rust", project_name="Test Project")
+        )
+        self.assertEqual(resp.status_code, 302)
+        sub.refresh_from_db()
+        self.assertCountEqual(sub.tags.names(), ["go", "rust"])
+

--- a/apps/submissions/views.py
+++ b/apps/submissions/views.py
@@ -119,7 +119,7 @@ class SubmitView(LoginRequiredMixin, FormView):
         s.links_json = form.cleaned_data.get("links_json", [])
         s.status = "published"
         s.save()
-        form.save_m2m()
+        s.tags.set(form.cleaned_data.get("tags", []))
         if editing:
             messages.success(self.request, "Submission updated successfully.")
         else:

--- a/templates/submissions/submit.html
+++ b/templates/submissions/submit.html
@@ -64,7 +64,13 @@
       {{ form.tech }}
       {{ form.tech.errors }}
     </div>
-    
+    <div class="field">
+      {{ form.tags.label_tag }}
+      {{ form.tags.help_text }}
+      {{ form.tags }}
+      {{ form.tags.errors }}
+    </div>
+
     <div class="field">
       {{ form.wins.label_tag }}
       {{ form.wins.help_text }}


### PR DESCRIPTION
## Summary
- replace `stack_tags` with generic `tags` on submissions
- update form, views, template and utilities to reference the new field
- adjust tests and migrations for renamed tag field

## Testing
- `uv run python manage.py test -v 2`

------
https://chatgpt.com/codex/tasks/task_e_68c1e5c430d08324aff8e0757c7777ff