### PR TITLE
Render comments in Markdown

### DIFF
--- a/apps/comments/models.py
+++ b/apps/comments/models.py
@@ -2,6 +2,7 @@ from django.conf import settings
 from django.db import models
 
 from apps.submissions.models import Submission
+from apps.submissions.markdown import render_markdown
 
 
 class Comment(models.Model):
@@ -21,3 +22,8 @@ class Comment(models.Model):
 
     def __str__(self):
         return f"Comment by {self.user.username} on {self.submission.project_name}"
+
+    @property
+    def content_html(self) -> str:
+        """Return sanitized HTML version of the comment content."""
+        return render_markdown(self.content)

--- a/apps/comments/tests.py
+++ b/apps/comments/tests.py
@@ -47,6 +47,16 @@ class CommentModelTests(TestCase):
         )
         self.assertEqual(reply.parent, parent)
 
+    def test_content_html_renders_markdown(self):
+        comment = Comment.objects.create(
+            user=self.user,
+            submission=self.submission,
+            content="**bold** <span>bad</span>",
+        )
+        html = comment.content_html
+        self.assertIn("<strong>bold</strong>", html)
+        self.assertNotIn("<span>", html)
+
 
 class CommentFormTests(TestCase):
     def test_valid_form(self):

--- a/templates/partials/comment.html
+++ b/templates/partials/comment.html
@@ -3,7 +3,7 @@
   {% if comment.is_deleted %}
     <p>[This comment is deleted by owner]</p>
   {% else %}
-    <p>{{ comment.content }}</p>
+    <p>{{ comment.content_html|safe }}</p>
     {% if request.user == comment.user or can_comment %}
       <div class="actions">
         {% if can_comment %}


### PR DESCRIPTION
## Summary
- Render comment content to sanitized HTML using the existing Markdown renderer
- Display rendered comment HTML in templates
- Test Markdown rendering and sanitization for comments

## Testing
- `just check`
- `just test`


------
https://chatgpt.com/codex/tasks/task_e_68c1edffc6388324909d589252509724